### PR TITLE
HBASE-23099 - [HBOSS] Raise hadoop dependency version to 3.2.1

### DIFF
--- a/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/HBaseObjectStoreSemanticsTest.java
+++ b/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/HBaseObjectStoreSemanticsTest.java
@@ -52,6 +52,7 @@ public class HBaseObjectStoreSemanticsTest {
   @Before
   public void setup() throws Exception {
     Configuration conf = new Configuration();
+    conf.addResource("contract/s3a.xml");
     hboss = TestUtils.getFileSystem(conf);
     sync = hboss.getLockManager();
     hboss.mkdirs(testPathRoot());

--- a/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/TestUtils.java
+++ b/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/TestUtils.java
@@ -102,7 +102,6 @@ public class TestUtils {
       return hboss;
     } catch (Exception e) {
       LOG.error(e.getMessage());
-      e.printStackTrace();
       throw e;
     }
   }
@@ -115,6 +114,19 @@ public class TestUtils {
       if (zk != null) {
         zk.conditionalStop();
       }
+    }
+  }
+
+  public static void runIfS3(boolean isS3, Configuration conf) {
+    try {
+      TestUtils.getFileSystem(conf);
+    } catch (Exception e) {
+      throw new AssertionError(e);
+    }
+    if(isS3) {
+      Assume.assumeTrue(TestUtils.fsIs(TestUtils.S3A, conf));
+    } else {
+      Assume.assumeFalse(TestUtils.fsIs(TestUtils.S3A, conf));
     }
   }
 }

--- a/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/contract/TestHBOSSContract.java
+++ b/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/contract/TestHBOSSContract.java
@@ -52,6 +52,7 @@ public class TestHBOSSContract extends FileSystemContractBaseTest {
   public void setUp() throws Exception {
     nameThread();
     conf = new Configuration();
+    conf.addResource("contract/s3a.xml");
     fs = TestUtils.getFileSystem(conf);
     Assume.assumeNotNull(fs);
     HBaseObjectStoreSemantics hboss = (HBaseObjectStoreSemantics)fs;

--- a/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/contract/TestHBOSSContractOpen.java
+++ b/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/contract/TestHBOSSContractOpen.java
@@ -21,6 +21,8 @@ package org.apache.hadoop.hbase.oss.contract;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractOpenTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.apache.hadoop.hbase.oss.TestUtils;
+import org.junit.Assume;
 
 public class TestHBOSSContractOpen extends AbstractContractOpenTest {
 
@@ -31,6 +33,14 @@ public class TestHBOSSContractOpen extends AbstractContractOpenTest {
 
   @Override
   protected AbstractFSContract createContract(Configuration conf) {
-    return new HBOSSContract(conf);
+    HBOSSContract contract = new HBOSSContract(conf);
+    try {
+      TestUtils.getFileSystem(conf);
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail("Exception configuring FS: " + e);
+    }
+    Assume.assumeFalse(TestUtils.fsIs(TestUtils.S3A, conf));
+    return contract;
   }
 }

--- a/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/contract/TestHBOSSContractOpen.java
+++ b/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/contract/TestHBOSSContractOpen.java
@@ -22,8 +22,12 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractOpenTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.apache.hadoop.hbase.oss.TestUtils;
-import org.junit.Assume;
 
+/**
+ * There is an S3A-specific extension of AbstractContractOpenTest
+ * that is similarly extended for HBOSS-on-S3A. This class remains to be run in
+ * the general case.
+ */
 public class TestHBOSSContractOpen extends AbstractContractOpenTest {
 
   @Override
@@ -33,14 +37,8 @@ public class TestHBOSSContractOpen extends AbstractContractOpenTest {
 
   @Override
   protected AbstractFSContract createContract(Configuration conf) {
-    HBOSSContract contract = new HBOSSContract(conf);
-    try {
-      TestUtils.getFileSystem(conf);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Exception configuring FS: " + e);
-    }
-    Assume.assumeFalse(TestUtils.fsIs(TestUtils.S3A, conf));
+    AbstractFSContract contract = new HBOSSContract(conf);
+    TestUtils.runIfS3(false, conf);
     return contract;
   }
 }

--- a/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/contract/TestHBOSSContractOpenS3A.java
+++ b/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/contract/TestHBOSSContractOpenS3A.java
@@ -21,7 +21,14 @@ package org.apache.hadoop.hbase.oss.contract;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractOpenTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.apache.hadoop.hbase.oss.TestUtils;
 
+
+/**
+ * For S3A-specific extension of AbstractContractOpenTest, we needed to override
+ * areZeroByteFilesEncrypted() method to always return true.
+ * TestHBOSSContractOpen remains to be run in the general case.
+ */
 public class TestHBOSSContractOpenS3A extends AbstractContractOpenTest {
 
   @Override
@@ -31,7 +38,9 @@ public class TestHBOSSContractOpenS3A extends AbstractContractOpenTest {
 
   @Override
   protected AbstractFSContract createContract(Configuration conf) {
-    return new HBOSSContract(conf);
+    AbstractFSContract contract = new HBOSSContract(conf);
+    TestUtils.runIfS3(true, conf);
+    return contract;
   }
 
   /**

--- a/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/contract/TestHBOSSContractOpenS3A.java
+++ b/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/contract/TestHBOSSContractOpenS3A.java
@@ -18,16 +18,11 @@
 
 package org.apache.hadoop.hbase.oss.contract;
 
-import java.net.URI;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.contract.AbstractContractRootDirectoryTest;
+import org.apache.hadoop.fs.contract.AbstractContractOpenTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hbase.oss.TestUtils;
-import org.junit.Assume;
 
-public class TestHBOSSContractRootDirectory extends AbstractContractRootDirectoryTest {
+public class TestHBOSSContractOpenS3A extends AbstractContractOpenTest {
 
   @Override
   protected Configuration createConfiguration() {
@@ -36,14 +31,14 @@ public class TestHBOSSContractRootDirectory extends AbstractContractRootDirector
 
   @Override
   protected AbstractFSContract createContract(Configuration conf) {
-    HBOSSContract contract = new HBOSSContract(conf);
-    try {
-      TestUtils.getFileSystem(conf);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Exception configuring FS: " + e);
-    }
-    Assume.assumeFalse(TestUtils.fsIs(TestUtils.S3A, conf));
-    return contract;
+    return new HBOSSContract(conf);
+  }
+
+  /**
+   * S3A always declares zero byte files as encrypted.
+   * @return true, always.
+   */
+  protected boolean areZeroByteFilesEncrypted() {
+    return true;
   }
 }

--- a/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/contract/TestHBOSSContractRename.java
+++ b/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/contract/TestHBOSSContractRename.java
@@ -18,14 +18,10 @@
 
 package org.apache.hadoop.hbase.oss.contract;
 
-import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.apache.hadoop.fs.contract.AbstractContractRenameTest;
-import org.apache.hadoop.hbase.oss.EmbeddedS3;
 import org.apache.hadoop.hbase.oss.TestUtils;
-import org.junit.Assume;
-import org.junit.Test;
 
 /**
  * There is an S3A-specific extension of AbstractContractRenameTest
@@ -42,13 +38,7 @@ public class TestHBOSSContractRename extends AbstractContractRenameTest {
   @Override
   protected AbstractFSContract createContract(Configuration conf) {
     HBOSSContract contract = new HBOSSContract(conf);
-    try {
-      TestUtils.getFileSystem(conf);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Exception configuring FS: " + e);
-    }
-    Assume.assumeFalse(TestUtils.fsIs(TestUtils.S3A, conf));
+    TestUtils.runIfS3(false, conf);
     return contract;
   }
 }

--- a/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/contract/TestHBOSSContractRenameS3A.java
+++ b/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/contract/TestHBOSSContractRenameS3A.java
@@ -18,17 +18,13 @@
 
 package org.apache.hadoop.hbase.oss.contract;
 
-import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.apache.hadoop.fs.contract.AbstractContractRenameTest;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
-import org.apache.hadoop.hbase.oss.EmbeddedS3;
 import org.apache.hadoop.hbase.oss.TestUtils;
-import org.junit.Assume;
-import org.junit.Test;
 
 /**
  * There is an S3A-specific extension of AbstractContractRenameTest, and this
@@ -45,13 +41,7 @@ public class TestHBOSSContractRenameS3A extends AbstractContractRenameTest {
   @Override
   protected AbstractFSContract createContract(Configuration conf) {
     HBOSSContract contract = new HBOSSContract(conf);
-    try {
-      TestUtils.getFileSystem(conf);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Exception configuring FS: " + e);
-    }
-    Assume.assumeTrue(TestUtils.fsIs(TestUtils.S3A, conf));
+    TestUtils.runIfS3(true, conf);
     return contract;
   }
 

--- a/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/contract/TestHBOSSContractRootDirectory.java
+++ b/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/contract/TestHBOSSContractRootDirectory.java
@@ -18,14 +18,10 @@
 
 package org.apache.hadoop.hbase.oss.contract;
 
-import java.net.URI;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractRootDirectoryTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.oss.TestUtils;
-import org.junit.Assume;
 
 public class TestHBOSSContractRootDirectory extends AbstractContractRootDirectoryTest {
 
@@ -37,13 +33,7 @@ public class TestHBOSSContractRootDirectory extends AbstractContractRootDirector
   @Override
   protected AbstractFSContract createContract(Configuration conf) {
     HBOSSContract contract = new HBOSSContract(conf);
-    try {
-      TestUtils.getFileSystem(conf);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Exception configuring FS: " + e);
-    }
-    Assume.assumeFalse(TestUtils.fsIs(TestUtils.S3A, conf));
+    TestUtils.runIfS3(false, conf);
     return contract;
   }
 }

--- a/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/contract/TestHBOSSContractRootDirectoryS3A.java
+++ b/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/contract/TestHBOSSContractRootDirectoryS3A.java
@@ -22,9 +22,14 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractRootDirectoryTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.apache.hadoop.hbase.oss.TestUtils;
-import org.junit.Assume;
 import org.junit.Ignore;
 
+/**
+ * For S3A-specific extension of AbstractContractRootDirectoryTest, this overrides
+ * testRmNonEmptyRootDirNonRecursive(), marking it as ignored, since
+ * HADOOP-16380 introduced changes on S3AFileSystem for delete not throw any exception.
+ * TestHBOSSContractRootDirectory remains to be run in the general case.
+ */
 public class TestHBOSSContractRootDirectoryS3A extends AbstractContractRootDirectoryTest {
 
   @Override
@@ -35,13 +40,7 @@ public class TestHBOSSContractRootDirectoryS3A extends AbstractContractRootDirec
   @Override
   protected AbstractFSContract createContract(Configuration conf) {
     HBOSSContract contract = new HBOSSContract(conf);
-    try {
-      TestUtils.getFileSystem(conf);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Exception configuring FS: " + e);
-    }
-    Assume.assumeTrue(TestUtils.fsIs(TestUtils.S3A, conf));
+    TestUtils.runIfS3(true, conf);
     return contract;
   }
 

--- a/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/contract/TestHBOSSContractRootDirectoryS3A.java
+++ b/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/contract/TestHBOSSContractRootDirectoryS3A.java
@@ -18,16 +18,14 @@
 
 package org.apache.hadoop.hbase.oss.contract;
 
-import java.net.URI;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractRootDirectoryTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.oss.TestUtils;
 import org.junit.Assume;
+import org.junit.Ignore;
 
-public class TestHBOSSContractRootDirectory extends AbstractContractRootDirectoryTest {
+public class TestHBOSSContractRootDirectoryS3A extends AbstractContractRootDirectoryTest {
 
   @Override
   protected Configuration createConfiguration() {
@@ -43,7 +41,13 @@ public class TestHBOSSContractRootDirectory extends AbstractContractRootDirector
       e.printStackTrace();
       fail("Exception configuring FS: " + e);
     }
-    Assume.assumeFalse(TestUtils.fsIs(TestUtils.S3A, conf));
+    Assume.assumeTrue(TestUtils.fsIs(TestUtils.S3A, conf));
     return contract;
+  }
+
+  //HADOOP-16380 introduced changes on S3AFileSystem for delete not throw any exception
+  @Override
+  @Ignore("S3 always return false when non-recursively remove root dir")
+  public void testRmNonEmptyRootDirNonRecursive() throws Throwable {
   }
 }

--- a/hbase-oss/src/test/resources/contract/s3a.xml
+++ b/hbase-oss/src/test/resources/contract/s3a.xml
@@ -125,4 +125,8 @@
     <value>false</value>
   </property>
 
+  <property>
+    <name>fs.s3a.change.detection.version.required</name>
+    <value>false</value>
+  </property>
 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <curator.version>4.2.0</curator.version>
     <guava.version>23.0</guava.version>
     <hadoop2.version>2.9.2</hadoop2.version>
-    <hadoop3.version>3.2.0</hadoop3.version>
+    <hadoop3.version>3.2.1</hadoop3.version>
     <hbase1.version>1.4.10</hbase1.version>
     <hbase2.version>2.1.4</hbase2.version>
     <hbase-thirdparty.version>2.2.1</hbase-thirdparty.version>


### PR DESCRIPTION
There's been some changes on S3Guard that comes with hadoop 3.2.1 and upcoming versions, such as HADOOP-16085, HADOOP-16233 and HADOOP-16380, among other recent commits. Some of these required additional properties or modified S3A expected behaviour for a few FS contract tests.