### PR TITLE
HBASE-23142 Include zookeeper-jute into hboss-thirdparty deps

### DIFF
--- a/hbase-oss/pom.xml
+++ b/hbase-oss/pom.xml
@@ -101,6 +101,7 @@
                   <include>org.apache.curator:curator-*:jar:*</include>
                   <include>org.apache.yetus:audience-annotations:jar:*</include>
                   <include>org.apache.zookeeper:zookeeper:jar:*</include>
+                  <include>org.apache.zookeeper:zookeeper-jute:jar:*</include>
                   <!-- transitives -->
                   <include>io.netty:netty</include>
                 </includes>


### PR DESCRIPTION
ZooKeeper 3.5 has a transitive dependency on zookeeper-jute.
This is a no-op for ZK 3.4.