### PR TITLE
HBASE-24124 hbase-filesystem to use guava from hbase-thirdparty

### DIFF
--- a/hbase-oss/pom.xml
+++ b/hbase-oss/pom.xml
@@ -197,24 +197,6 @@
       <version>${commons-lang3.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-      <exclusions>
-        <exclusion>
-          <!-- Banned import in HBase -->
-          <groupId>com.google.code.findbugs</groupId>
-          <artifactId>jsr305</artifactId>
-        </exclusion>
-        <exclusion>
-          <!-- this should have been marked optional by guava because
-               the annotation are retention CLASS -->
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>animal-sniffer-annotations</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>

--- a/hbase-oss/pom.xml
+++ b/hbase-oss/pom.xml
@@ -96,7 +96,6 @@
                 -->
               <artifactSet>
                 <includes>
-                  <!--<include>com.google.*:*:jar:*</include>-->
                   <include>org.apache.commons:commons-lang3:jar:*</include>
                   <include>org.apache.curator:curator-*:jar:*</include>
                   <include>org.apache.yetus:audience-annotations:jar:*</include>
@@ -107,10 +106,6 @@
                 </includes>
               </artifactSet>
               <relocations>
-                <!--<relocation>
-                  <pattern>com.google</pattern>
-                  <shadedPattern>${shading.prefix}.com.google</shadedPattern>
-                </relocation>-->
                 <relocation>
                   <pattern>org.apache.commons</pattern>
                   <shadedPattern>${shading.prefix}.org.apache.commons</shadedPattern>

--- a/hbase-oss/pom.xml
+++ b/hbase-oss/pom.xml
@@ -96,7 +96,7 @@
                 -->
               <artifactSet>
                 <includes>
-                  <include>com.google.*:*:jar:*</include>
+                  <!--<include>com.google.*:*:jar:*</include>-->
                   <include>org.apache.commons:commons-lang3:jar:*</include>
                   <include>org.apache.curator:curator-*:jar:*</include>
                   <include>org.apache.yetus:audience-annotations:jar:*</include>
@@ -107,10 +107,10 @@
                 </includes>
               </artifactSet>
               <relocations>
-                <relocation>
+                <!--<relocation>
                   <pattern>com.google</pattern>
                   <shadedPattern>${shading.prefix}.com.google</shadedPattern>
-                </relocation>
+                </relocation>-->
                 <relocation>
                   <pattern>org.apache.commons</pattern>
                   <shadedPattern>${shading.prefix}.org.apache.commons</shadedPattern>

--- a/hbase-oss/src/main/java/org/apache/hadoop/hbase/oss/HBaseObjectStoreSemantics.java
+++ b/hbase-oss/src/main/java/org/apache/hadoop/hbase/oss/HBaseObjectStoreSemantics.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.hbase.oss;
 
-import org.apache.hbase.thirdparty.com.google.common.annotations.VisibleForTesting;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
@@ -58,6 +57,7 @@ import org.apache.hadoop.hbase.oss.sync.TreeLockManager;
 import org.apache.hadoop.hbase.oss.sync.TreeLockManager.Depth;
 import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.util.Progressable;
+import org.apache.hbase.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.yetus.audience.InterfaceStability;
 import org.slf4j.Logger;

--- a/hbase-oss/src/main/java/org/apache/hadoop/hbase/oss/HBaseObjectStoreSemantics.java
+++ b/hbase-oss/src/main/java/org/apache/hadoop/hbase/oss/HBaseObjectStoreSemantics.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.hbase.oss;
 
-import com.google.common.annotations.VisibleForTesting;
+import org.apache.hbase.thirdparty.com.google.common.annotations.VisibleForTesting;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;

--- a/hbase-oss/src/main/java/org/apache/hadoop/hbase/oss/sync/TreeLockManager.java
+++ b/hbase-oss/src/main/java/org/apache/hadoop/hbase/oss/sync/TreeLockManager.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.hbase.oss.sync;
 
-import com.google.common.annotations.VisibleForTesting;
+import org.apache.hbase.thirdparty.com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;

--- a/hbase-oss/src/main/java/org/apache/hadoop/hbase/oss/sync/TreeLockManager.java
+++ b/hbase-oss/src/main/java/org/apache/hadoop/hbase/oss/sync/TreeLockManager.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.hbase.oss.sync;
 
-import org.apache.hbase.thirdparty.com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
@@ -31,6 +30,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.oss.Constants;
+import org.apache.hbase.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.yetus.audience.InterfaceStability;
 import org.slf4j.Logger;

--- a/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/sync/LocalTreeLockManager.java
+++ b/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/sync/LocalTreeLockManager.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.hbase.oss.sync;
 
-import org.apache.hbase.thirdparty.com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
@@ -29,6 +28,7 @@ import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hbase.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/sync/LocalTreeLockManager.java
+++ b/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/sync/LocalTreeLockManager.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.hbase.oss.sync;
 
-import com.google.common.annotations.VisibleForTesting;
+import org.apache.hbase.thirdparty.com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;

--- a/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/sync/NullTreeLockManager.java
+++ b/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/sync/NullTreeLockManager.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.hbase.oss.sync;
 
-import com.google.common.annotations.VisibleForTesting;
+import org.apache.hbase.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;

--- a/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/sync/NullTreeLockManager.java
+++ b/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/sync/NullTreeLockManager.java
@@ -18,10 +18,10 @@
 
 package org.apache.hadoop.hbase.oss.sync;
 
-import org.apache.hbase.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hbase.thirdparty.com.google.common.annotations.VisibleForTesting;
 
 /**
  * Bypasses all synchronization to effectively make HBOSS operations no-ops.

--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,12 @@
           <type>test-jar</type>
           <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>org.apache.hbase.thirdparty</groupId>
+          <artifactId>hbase-shaded-miscellaneous</artifactId>
+          <version>${hbase-thirdparty.version}</version>
+          <scope>provided</scope>
+        </dependency>
       </dependencies>
     </profile>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,6 @@
     <commons-io.version>2.5</commons-io.version>
     <commons-lang3.version>3.6</commons-lang3.version>
     <curator.version>4.2.0</curator.version>
-    <guava.version>23.0</guava.version>
     <hadoop2.version>2.9.2</hadoop2.version>
     <hadoop3.version>3.2.1</hadoop3.version>
     <hbase1.version>1.4.10</hbase1.version>


### PR DESCRIPTION
Removed guava in pom.xml. Use org.apache.hbase.thirdparty.com.google.common.* instead.