### PR TITLE
HBASE-25900. HBoss tests compile/failure against Hadoop 3.3.1

### DIFF
--- a/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/EmbeddedS3.java
+++ b/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/EmbeddedS3.java
@@ -51,6 +51,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -99,10 +101,17 @@ public class EmbeddedS3 {
    * we are omitting "@override" annotation from overridden methods.
    */
   public static class EmbeddedS3ClientFactory implements S3ClientFactory {
-
     public AmazonS3 createS3Client(URI name) {
       AmazonS3 s3 = new EmbeddedAmazonS3();
       s3.createBucket(BUCKET);
+      return s3;
+    }
+
+    public AmazonS3 createS3Client(URI uri,
+        S3ClientCreationParameters s3ClientCreationParameters)
+        throws IOException {
+      AmazonS3 s3 = new EmbeddedAmazonS3();
+      s3.createBucket(uri.getHost());
       return s3;
     }
 
@@ -172,7 +181,7 @@ public class EmbeddedS3 {
       }
     }
 
-    private Map<String, EmbeddedS3Object> bucket = new HashMap<>();
+    private Map<String, EmbeddedS3Object> bucket = new ConcurrentHashMap<>();
 
     private void simulateServerSideCopy() {
       try {

--- a/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/contract/TestHBOSSContractCreate.java
+++ b/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/contract/TestHBOSSContractCreate.java
@@ -43,6 +43,12 @@ public class TestHBOSSContractCreate extends AbstractContractCreateTest {
   @Test
   @Override
   public void testCreatedFileIsVisibleOnFlush() throws Throwable {
+
+    skipIfFilesNotVisibleDuringCreation();
+    super.testCreatedFileIsVisibleOnFlush();
+  }
+
+  private void skipIfFilesNotVisibleDuringCreation() {
     Configuration conf = createConfiguration();
     try {
       TestUtils.getFileSystem(conf);
@@ -53,7 +59,6 @@ public class TestHBOSSContractCreate extends AbstractContractCreateTest {
     // HBOSS satisfies the contract that this test checks for, but it also
     // relies on flush, which s3a still does not support.
     Assume.assumeFalse(TestUtils.fsIs(TestUtils.S3A, conf));
-    super.testCreatedFileIsVisibleOnFlush();
   }
 
   @Test
@@ -84,5 +89,10 @@ public class TestHBOSSContractCreate extends AbstractContractCreateTest {
                          path);
       }
     }
+  }
+
+  public void testSyncable() throws Throwable {
+    skipIfFilesNotVisibleDuringCreation();
+    super.testSyncable();
   }
 }

--- a/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/contract/TestHBOSSContractRenameS3A.java
+++ b/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/contract/TestHBOSSContractRenameS3A.java
@@ -26,6 +26,8 @@ import org.apache.hadoop.fs.contract.AbstractContractRenameTest;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.hbase.oss.TestUtils;
 
+import static org.apache.hadoop.fs.contract.ContractTestUtils.skip;
+
 /**
  * There is an S3A-specific extension of AbstractContractRenameTest, and this
  * class implements the same modifications for HBOSS-on-S3A.
@@ -68,5 +70,10 @@ public class TestHBOSSContractRenameS3A extends AbstractContractRenameTest {
 
     boolean rename = fs.rename(srcDir, destDir);
     assertFalse("s3a doesn't support rename to non-empty directory", rename);
+  }
+
+  @Override
+  public void testRenameFileUnderFileSubdir() throws Exception {
+    skip("Rename deep paths under files is allowed");
   }
 }

--- a/hbase-oss/src/test/resources/contract/s3a.xml
+++ b/hbase-oss/src/test/resources/contract/s3a.xml
@@ -26,6 +26,10 @@
       fs.contract.supports-atomic-directory-delete = true
       fs.contract.supports-atomic-rename = true
 
+    fs.contract.is-blobstore tells the tests "don't expect it to be visible
+    during creation"
+
+    "fs.contract.create-visibility-delayed."
     Note that fs.contract.is-blobstore appears to be identical in meaning to
     fs.contract.create-visibility-delayed.
   -->
@@ -54,10 +58,24 @@
     <name>fs.contract.is-case-sensitive</name>
     <value>true</value>
   </property>
+  <property>
+    <name>fs.contract.rename-creates-dest-dirs</name>
+    <value>true</value>
+  </property>
 
   <property>
     <name>fs.contract.rename-returns-false-if-source-missing</name>
-    <value>true</value>
+    <value>false</value>
+  </property>
+
+  <property>
+    <name>fs.contract.rename-overwrites-dest</name>
+    <value>false</value>
+  </property>
+
+  <property>
+    <name>fs.contract.rename-returns-false-if-dest-exists</name>
+    <value>false</value>
   </property>
 
   <property>


### PR DESCRIPTION

Fixes the build to

* optionally look in the ASF snapshots and staging repos
* build with hadoop-3.3.1
* tests to work with hadoop-3.3.1
* assertJ added to the classpath (something is odd with hadoop-common-test here; seen elsewhere. Will need to revisit).

This fixes the s3 client factory to use the new parameter object to configure the client. This will allow the hadoop code to add new options (it already has related to regions), without HBoss builds failing. We've also tagged the API as limited private and mentioned HBoss as users of it, so future maintainers will know to be careful.