### PR TITLE
HBASE-26437 Clean up the znodes for the src after a rename.

### DIFF
--- a/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/HBaseObjectStoreSemanticsTest.java
+++ b/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/HBaseObjectStoreSemanticsTest.java
@@ -43,6 +43,10 @@ public class HBaseObjectStoreSemanticsTest {
     return TestUtils.testPath(hboss, path);
   }
 
+  public TreeLockManager getLockManager() {
+    return sync;
+  }
+
   @Before
   public void setup() throws Exception {
     Configuration conf = new Configuration();

--- a/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/TestZNodeCleanup.java
+++ b/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/TestZNodeCleanup.java
@@ -1,0 +1,176 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.oss;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import java.util.concurrent.CountDownLatch;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.oss.sync.ZKTreeLockManager;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.Watcher.Event.KeeperState;
+import org.apache.zookeeper.ZooKeeper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Validates that when some entry in the object store is deleted, the corresponding
+ * data in ZooKeeper is also deleted.
+ */
+public class TestZNodeCleanup extends HBaseObjectStoreSemanticsTest {
+  private static final Logger LOG = LoggerFactory.getLogger(TestZNodeCleanup.class);
+
+  private ZKTreeLockManager lockManager;
+  private ZooKeeper zk;
+
+  @Before
+  public void setup() throws Exception {
+    super.setup();
+    assumeTrue("Lock manager is a " + getLockManager().getClass(),
+        getLockManager() instanceof ZKTreeLockManager);
+    lockManager = (ZKTreeLockManager) getLockManager();
+    Configuration conf = hboss.getConf();
+    LOG.info("Waiting for ZK client to connect");
+    // TODO should wait for ZK to connect
+    final CountDownLatch latch = new CountDownLatch(1);
+    // Root the ZK connection beneath /hboss
+    zk = new ZooKeeper(conf.get(Constants.ZK_CONN_STRING) + "/hboss", 60000, new Watcher() {
+      @Override
+      public void process(WatchedEvent event) {
+        LOG.info("Caught event " + event);
+        if (event.getState() == KeeperState.SyncConnected) {
+          latch.countDown();
+        }
+      }
+    });
+    latch.await();
+    LOG.info("ZooKeeper client is connected");
+  }
+
+  @After
+  public void teardown() throws Exception {
+    if (zk != null) {
+      zk.close();
+      zk = null;
+    }
+  }
+
+  String getZNodeFromPath(Path p) {
+    return Path.getPathWithoutSchemeAndAuthority(p).toString().substring(1);
+  }
+
+  void validatePathInZk(Path zkPath) throws Exception {
+    assertNotNull(zkPath + " did not exist in ZK", zk.exists(zkPath.toString(), false));
+    String hbossLock = new Path(zkPath, ZKTreeLockManager.LOCK_SUB_ZNODE).toString();
+    assertNotNull(hbossLock + " did not exist in ZK", zk.exists(hbossLock, false));
+  }
+
+  void validatePathNotInZk(Path zkPath) throws Exception {
+    assertNull(zkPath + " incorrectly exists in ZK.", zk.exists(zkPath.toString(), false));
+  }
+
+  @Test
+  public void testRename() throws Exception {
+    // Rename src to dest and validate that the znode for src is cleaned up.
+    final Path src = TestUtils.testPath(hboss, "src");
+    final Path dest = TestUtils.testPath(hboss, "dest");
+    assertTrue(hboss.mkdirs(src));
+    // The src znode should exist after creating the dir in S3
+    validatePathInZk(lockManager.norm(src));
+    // `mv src dest`
+    assertTrue(hboss.rename(src, dest));
+    // We should have a znode for dest (we just locked it)
+    validatePathInZk(lockManager.norm(dest));
+    // We should no longer have a znode for src (we effectively deleted it from S3)
+    validatePathNotInZk(lockManager.norm(src));
+  }
+
+  @Test
+  public void testFailedRename() throws Exception {
+    // Rename src to dest and validate that the znode for src is cleaned up.
+    final Path src = TestUtils.testPathRoot(hboss);
+    final Path dest = TestUtils.testPath(hboss, "dest");
+    assertTrue(hboss.mkdirs(src));
+    // The src znode should exist after creating the dir in S3
+    validatePathInZk(lockManager.norm(src));
+    // The move should fail
+    assertFalse(hboss.rename(src, dest));
+    // We should have a znode for dest (we just locked it)
+    validatePathInZk(lockManager.norm(src));
+    // We should no longer have a znode for src (we effectively deleted it from S3)
+    validatePathInZk(lockManager.norm(dest));
+  }
+
+  @Test
+  public void testRenameDeeperToHigher() throws Exception {
+    // Rename src to dest and validate that the znode for src is cleaned up.
+    final Path src = TestUtils.testPath(hboss, "/a/b/1");
+    final Path dest = TestUtils.testPath(hboss, "/a/1");
+    assertTrue(hboss.mkdirs(src));
+    // The src znode should exist after creating the dir in S3
+    validatePathInZk(lockManager.norm(src));
+    // mv /a/b/1 /a/1
+    assertTrue(hboss.rename(src, dest));
+    // We should not have a znode for the src
+    validatePathNotInZk(lockManager.norm(src));
+    // We should have a lock for the dest
+    validatePathInZk(lockManager.norm(dest));
+  }
+
+  @Test
+  public void testRenameHigherToDeeper() throws Exception {
+    // Rename src to dest and validate that the znode for src is cleaned up.
+    final Path src = TestUtils.testPath(hboss, "/a/1");
+    final Path dest = TestUtils.testPath(hboss, "/a/b/1");
+    // `mkdir /a/1`
+    assertTrue(hboss.mkdirs(src));
+    // The src znode should exist after creating the dir in S3
+    validatePathInZk(lockManager.norm(src));
+    // `mkdir /a/b`
+    assertTrue(hboss.mkdirs(dest.getParent()));
+    // `mv /a/1 /a/b/1`
+    assertTrue(hboss.rename(src, dest));
+    // We should have a znode for dest (we just locked it)
+    validatePathNotInZk(lockManager.norm(src));
+    // We should no longer have a znode for src (we effectively deleted it from S3)
+    validatePathInZk(lockManager.norm(dest));
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    // Delete src and validate that the znode for src is cleaned up.
+    final Path src = TestUtils.testPath(hboss, "src");
+    assertTrue(hboss.mkdirs(src));
+    // The src znode should exist after creating the dir in S3
+    validatePathInZk(lockManager.norm(src));
+    // `mv src dest`
+    assertTrue(hboss.delete(src, true));
+    // We should no longer have a znode for src since we deleted it from S3
+    validatePathNotInZk(lockManager.norm(src));
+  }
+}

--- a/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/TestZNodeCleanup.java
+++ b/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/TestZNodeCleanup.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
 import org.apache.hadoop.conf.Configuration;
@@ -74,9 +75,20 @@ public class TestZNodeCleanup extends HBaseObjectStoreSemanticsTest {
 
   @After
   public void teardown() throws Exception {
+    String zkRoot = lockManager.norm(TestUtils.testPathRoot(hboss)).toString();
+    LOG.info("Dumping contents of ZooKeeper after test from {}", zkRoot);
+    printZkBFS(zkRoot);
     if (zk != null) {
       zk.close();
       zk = null;
+    }
+  }
+
+  void printZkBFS(String path) throws Exception {
+    LOG.info(path);
+    List<String> children = zk.getChildren(path, false);
+    for (String child : children) {
+      printZkBFS(path + "/" + child);
     }
   }
 

--- a/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/contract/TestHBOSSContract.java
+++ b/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/contract/TestHBOSSContract.java
@@ -46,6 +46,11 @@ public class TestHBOSSContract extends FileSystemContractBaseTest {
   @Rule
   public TestName methodName = new TestName();
 
+  @Override
+  protected int getGlobalTimeout() {
+    return Integer.MAX_VALUE;
+  }
+
   private void nameThread() {
     Thread.currentThread().setName("JUnit-" + methodName.getMethodName());
   }

--- a/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/contract/TestHBOSSContract.java
+++ b/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/contract/TestHBOSSContract.java
@@ -46,11 +46,6 @@ public class TestHBOSSContract extends FileSystemContractBaseTest {
   @Rule
   public TestName methodName = new TestName();
 
-  @Override
-  protected int getGlobalTimeout() {
-    return Integer.MAX_VALUE;
-  }
-
   private void nameThread() {
     Thread.currentThread().setName("JUnit-" + methodName.getMethodName());
   }

--- a/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/sync/TestTreeLockManager.java
+++ b/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/sync/TestTreeLockManager.java
@@ -36,7 +36,7 @@ public class TestTreeLockManager extends HBaseObjectStoreSemanticsTest {
 
   @Test
   public void testLockBelowChecks() throws Exception {
-    Assume.assumeFalse(sync instanceof NullTreeLockManager);
+    Assume.assumeFalse(getLockManager() instanceof NullTreeLockManager);
 
     Path parent = testPath("testListingLevels");
     Path child = new Path(parent, "child");

--- a/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/sync/TestZKTreeLockManager.java
+++ b/hbase-oss/src/test/java/org/apache/hadoop/hbase/oss/sync/TestZKTreeLockManager.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.oss.sync;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.hadoop.fs.Path;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestZKTreeLockManager {
+  ZKTreeLockManager manager;
+
+  @Before
+  public void setup() {
+    this.manager = new ZKTreeLockManager();
+  }
+
+  @Test
+  public void testIsBeneath() {
+    assertFalse(manager.isBeneath(new Path("/foo"), new Path("/bar")));
+    assertTrue(manager.isBeneath(new Path("/foo"), new Path("/foo/bar")));
+    assertFalse(manager.isBeneath(new Path("/foo"), new Path("/foo2")));
+    assertTrue(manager.isBeneath(new Path("/foo/bar"), new Path("/foo/bar/2")));
+    assertFalse(manager.isBeneath(new Path("/foo"), new Path("/foo")));
+  }
+}

--- a/hbase-oss/src/test/resources/log4j.properties
+++ b/hbase-oss/src/test/resources/log4j.properties
@@ -17,3 +17,5 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c{2} (%F:%M(%L)) - %m%n
 log4j.logger.org.apache.hadoop=DEBUG
+log4j.logger.org.apache.hadoop.metrics2=WARN
+log4j.logger.org.apache.hadoop.fs=WARN


### PR DESCRIPTION
HBOSS was orphaning znodes from the src of a path which is renamed. Over
time, this will result in a very large usage of ZK due to HBOSS.